### PR TITLE
v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,21 @@ Just starting with Janet? See the official language introduction [here](https://
   - `Alt+Up/Down` to drag S-Exp forward/backward
   - "Slurp" (extend parentheses), "Barf" (shrink parentheses), and other PareEdit commands (see [this visual guide to ParEdit on the Calva website](https://calva.io/paredit/) for more info, most of which applies without modification to this extension too)
 - Language Server Protocol via embedded [Janet LSP](https://www.github.com/CFiggers/janet-lsp)
-  - Inline compiler error underlining (glitchy on Windows at the moment)
+  - Inline compiler error underlining
   - Function and macro autocomplete
   - On-hover symbol definitions
 
 More coming soon!
+
+# Usage
+
+## Janet LSP and `startup.janet`
+
+Janet LSP works by running a copy of the Janet runtime and flychecking (that is, compiling but not fully evaluating) the code in your active editor window using that runtime instance. This allows for on-hover documentation and compiler warnings to be provided by Janet itself.
+
+Sometimes, you may need to pre-load modules or modify the environment table in other ways in order for the LSP's runtime to correctly recognize the code in your editor. In such cases, you can create a `.janet-lsp/` directory in your project's root and add a `startup.janet` file to that folder. If such a startup script is detected, the LSP will fully execute it prior to initiating the startup handshake with your editor.
+
+The code in `startup.janet` is normal Janet source code that is executed by the server's runtime. **Don't put any code you don't completely trust in `startup.janet`.**
 
 # Contributing
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Janet++",
 	"description": "Expanded Janet language support for Visual Studio Code",
 	"icon": "images/icon_png_minimal_glow.png",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"author": "Caleb Figgers",
 	"publisher": "CalebFiggers",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,12 @@
 						"markdownDescription": "Whether or not to start up an LSP for Janet when activating Janet++. By default, will start up [Janet LSP](https://www.github.com/CFiggers/janet-lsp), which ships with Janet++.",
 						"default": true
 					},
+					"janet.lsp.dontDiscoverJpmTree": {
+						"type": "boolean",
+						"markdownDescription": "Instruct Janet LSP not to discover modules stored project-locally in `jpm_tree`.",
+						"default": false,
+						"title": "Don't Discover JPM Tree"
+					},
 					"janet.lsp.customJanetLspCommand": {
 						"type": "string",
 						"markdownDescription": "A custom command to execute when attempting to launch an LSP for Janet. This command will be attempted as though run at the command line and should result in a persistent server process that can handle LSP requests via STDIO."

--- a/src/config.ts
+++ b/src/config.ts
@@ -166,8 +166,9 @@ function getConfig() {
     definitionProviderPriority: configOptions.get<string[]>('definitionProviderPriority'),
 
     // Janet LSP
-    enableLsp: lspOptions.get<boolean>('enableLsp'),
     customJanetLspCommand: lspOptions.get<string[]>('customJanetLspCommand', []),
+    dontDiscoverJpmTree: lspOptions.get<boolean>('dontDiscoverJpmTree'),
+    enableLsp: lspOptions.get<boolean>('enableLsp')
   };
 }
 

--- a/src/lsp/extension.ts
+++ b/src/lsp/extension.ts
@@ -79,6 +79,18 @@ function getServerImage(): string {
     // );
 }
 
+function getDiscoverJpmTreeOpt(): string[] {
+    let discoverJpmTreeOpt: string[];
+
+    if (config.getConfig().dontDiscoverJpmTree){
+        discoverJpmTreeOpt = ["--dont-search-jpm-tree"];
+    } else {
+        discoverJpmTreeOpt = [];
+    }
+
+    return discoverJpmTreeOpt;
+}
+
 function getServerOptions(): ServerOptions {
     let options: ServerOptions;
 
@@ -91,7 +103,7 @@ function getServerOptions(): ServerOptions {
     } else {
         options = {
             command: "janet",
-            args: ["-i", getServerImage()],
+            args: ["-i", getServerImage()].concat(getDiscoverJpmTreeOpt()),
             transport: TransportKind.stdio
         };
     }


### PR DESCRIPTION
- Improvements
  - Auto-discover local modules saved to `jpm_tree` (or disable that behavior with a new setting)
  - Customize the startup of Janet LSP with `.janet-lsp/startup.janet` in your project's root
- Bugfixes
  - Incomplete `(case)` statement was causing LSP to crash on Mac OS