### PR TITLE
Adds LSP --debug flag option to settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,12 @@
 						"default": false,
 						"title": "Don't Discover JPM Tree"
 					},
+					"janet.lsp.debugLsp": {
+						"type": "boolean",
+						"markdownDescription": "Start Janet LSP in `--debug` mode. Must be manually restarted to take effect. Ignored when `#janet.lsp.customJanetLspCommand#` is set.",
+						"default": false,
+						"title": "Debug Janet LSP"
+					},
 					"janet.lsp.customJanetLspCommand": {
 						"type": "string",
 						"markdownDescription": "A custom command to execute when attempting to launch an LSP for Janet. This command will be attempted as though run at the command line and should result in a persistent server process that can handle LSP requests via STDIO.\n\nThe recommended strategy is to `jpm install` your own custom janet-lsp project and then set this field to `janet-lsp`."

--- a/src/config.ts
+++ b/src/config.ts
@@ -168,7 +168,8 @@ function getConfig() {
     // Janet LSP
     customJanetLspCommand: lspOptions.get<string>('customJanetLspCommand'),
     dontDiscoverJpmTree: lspOptions.get<boolean>('dontDiscoverJpmTree'),
-    enableLsp: lspOptions.get<boolean>('enableLsp')
+    enableLsp: lspOptions.get<boolean>('enableLsp'),
+    debugLsp: lspOptions.get<boolean>('debugLsp')
   };
 }
 

--- a/src/lsp/extension.ts
+++ b/src/lsp/extension.ts
@@ -236,7 +236,9 @@ export async function activate(context: ExtensionContext) {
 
     if (vscode.env.sessionId != context.workspaceState.get('janet.lsp.debugSession')) {
         // Reset LSP debug flag in user settings on vscode start.
-        await vscode.workspace.getConfiguration().update('janet.lsp.debugLsp', false, true);
+        if (config.getConfig().debugLsp) {
+            await vscode.workspace.getConfiguration().update('janet.lsp.debugLsp', undefined, true);
+        }
         context.workspaceState.update('janet.lsp.debugSession', vscode.env.sessionId);
     }
     

--- a/src/lsp/extension.ts
+++ b/src/lsp/extension.ts
@@ -93,6 +93,18 @@ function getDiscoverJpmTreeOpt(): string[] {
     return discoverJpmTreeOpt;
 }
 
+function getDebugLspOpt(): string[] {
+    let debugLsp: string[];
+
+    if (config.getConfig().debugLsp) {
+        debugLsp = ["--debug"];
+    } else {
+        debugLsp = [];
+    }
+
+    return debugLsp;
+}
+
 function getServerOptions(): ServerOptions {
     let options: ServerOptions;
     const lspConfig = config.getConfig().customJanetLspCommand;
@@ -107,7 +119,8 @@ function getServerOptions(): ServerOptions {
     } else {
         options = {
             command: "janet",
-            args: ["-i", getServerImage()].concat(getDiscoverJpmTreeOpt()),
+            args: ["-i", getServerImage()]
+                .concat(getDiscoverJpmTreeOpt(), getDebugLspOpt()),
             transport: TransportKind.stdio
         };
     }
@@ -173,7 +186,7 @@ function getServerOptions(): ServerOptions {
 //   }
 // }
 
-export function activate(context: ExtensionContext) {
+export async function activate(context: ExtensionContext) {
     
     // TODO: Add a status bar showing current health of janet-lsp 
 
@@ -220,6 +233,16 @@ export function activate(context: ExtensionContext) {
 	// 	args: ["-i", getServerImage()],
 	// 	transport: TransportKind.stdio
 	// };
+
+    if (vscode.env.sessionId != context.workspaceState.get('janet.lsp.debugSession')) {
+        // Reset LSP debug flag in user settings on vscode start.
+        await vscode.workspace.getConfiguration().update('janet.lsp.debugLsp', false, true);
+        context.workspaceState.update('janet.lsp.debugSession', vscode.env.sessionId);
+    }
+    
+    if (config.getConfig().debugLsp && !config.getConfig().customJanetLspCommand) {
+        vscode.window.showInformationMessage('Janet LSP debugging enabled.');
+    }
 
     const serverOptions: ServerOptions = getServerOptions();
 

--- a/src/lsp/extension.ts
+++ b/src/lsp/extension.ts
@@ -186,7 +186,7 @@ function getServerOptions(): ServerOptions {
 //   }
 // }
 
-export async function activate(context: ExtensionContext) {
+export function activate(context: ExtensionContext) {
     
     // TODO: Add a status bar showing current health of janet-lsp 
 
@@ -233,14 +233,6 @@ export async function activate(context: ExtensionContext) {
 	// 	args: ["-i", getServerImage()],
 	// 	transport: TransportKind.stdio
 	// };
-
-    if (vscode.env.sessionId != context.workspaceState.get('janet.lsp.debugSession')) {
-        // Reset LSP debug flag in user settings on vscode start.
-        if (config.getConfig().debugLsp) {
-            await vscode.workspace.getConfiguration().update('janet.lsp.debugLsp', undefined, true);
-        }
-        context.workspaceState.update('janet.lsp.debugSession', vscode.env.sessionId);
-    }
     
     if (config.getConfig().debugLsp && !config.getConfig().customJanetLspCommand) {
         vscode.window.showInformationMessage('Janet LSP debugging enabled.');


### PR DESCRIPTION
Adds a setting to enable the `--debug` flag for the Janet LSP. This does _not_ add a debug flag when using the Custom command. Potentially closes #32 

Thoughts?