### PR TITLE
v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Change Log
 
+## v1.1.9 (2024-12-22, Pre-release)
+
+- Extension
+  - New feature: Auto-activate extension when `project.janet` is detected in project tree
+  - New feature: Setting to auto-start REPL on extension activation
+- Settings
+  - New option to enable Debug flag on launch
+  - New options to set LSP Log level and Log to File Level (on launch and on change)
+  - New option to set Console port on launch
+- Janet LSP
+  - Update to v0.0.10 
+    - Logging 
+      - Rotate log files and overwrite eventually to avoid indefinite log file size
+      - Adjusted some log levels
+    - New methods
+      - `enableDebug` and `disableDebug` - Allow clients to set `(dyn :debug)` while running
+      - `setLogLevel` and `setLogToFileLevel` - Allow clients to change debug level to console and file
+  - Related commands 
+    - New commands to Enable and Disable Debug
+    - New commands to set Log Level and Log to File Level
+    - New command to Restart LSP
+
 ## v1.1.8 (2024-12-20)
 
 - Changes in v1.1.7 promoted to full release

--- a/package.json
+++ b/package.json
@@ -245,6 +245,13 @@
 			},
 			{
 				"category": "Janet LSP",
+				"command": "janet.lsp.restartLsp",
+				"title": "Restart Janet LSP",
+				"when": "editorLangId == janet",
+				"enablement": "editorLangId == janet"
+			},
+			{
+				"category": "Janet LSP",
 				"command": "janet.lsp.enableDebug",
 				"title": "Enable Debug Logging",
 				"when": "editorLangId == janet",

--- a/package.json
+++ b/package.json
@@ -203,6 +203,10 @@
 						],
 						"default": "verbose",
 						"description": "Sets the detail level of debug logs printed to `janetlsp.log` file. Only applies when :debug is enabled on the server."
+					},
+					"janet.lsp.consolePort": {
+						"type": "string",
+						"description": "Start the LSP listening to a custom port for purposes of connecting to the `janet-lsp --console` CLI option."
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -145,7 +145,8 @@
 					"janet.lsp.enableLsp": {
 						"type": "boolean",
 						"markdownDescription": "Whether or not to start up an LSP for Janet when activating Janet++. By default, will start up [Janet LSP](https://www.github.com/CFiggers/janet-lsp), which ships with Janet++.",
-						"default": true
+						"default": true,
+						"order": 0
 					},
 					"janet.lsp.dontDiscoverJpmTree": {
 						"type": "boolean",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
 		"Programming Languages",
 		"Formatters"
 	],
-	"activationEvents": [],
+	"activationEvents": [
+		"workspaceContains:**/project.janet"
+	],
 	"main": "./dist/extension.js",
 	"contributes": {
 		"iconThemes": [],

--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
 						"description": "Activate keybindings.",
 						"default": true,
 						"scope": "window"
+					},
+					"janet.autoStartRepl": {
+					  "type": "boolean",
+					  "default": false,
+					  "markdownDescription": "If true, Janet++ will auto-start and connect Janet REPL when a Janet project is opened."
 					}
 				}
 			},

--- a/package.json
+++ b/package.json
@@ -177,6 +177,30 @@
 						],
 						"default": "off",
 						"description": "Traces the communication between VS Code and the language server."
+					},
+					"janet.lsp.loggingdetail.console": {
+						"scope": "window",
+						"type": "string",
+						"enum": [
+							"off",
+							"messages",
+							"verbose",
+							"veryverbose"
+						],
+						"default": "messages",
+						"description": "Sets the detail level of debug logs printed to console. Only applies when :debug is enabled on the server."
+					},
+					"janet.lsp.loggingdetail.file": {
+						"scope": "window",
+						"type": "string",
+						"enum": [
+							"off",
+							"messages",
+							"verbose",
+							"veryverbose"
+						],
+						"default": "verbose",
+						"description": "Sets the detail level of debug logs printed to `janetlsp.log` file. Only applies when :debug is enabled on the server."
 					}
 				}
 			}
@@ -216,6 +240,20 @@
 				"category": "Janet LSP",
 				"command": "janet.lsp.tellJoke",
 				"title": "Tell a Joke",
+				"when": "editorLangId == janet",
+				"enablement": "editorLangId == janet"
+			},
+			{
+				"category": "Janet LSP",
+				"command": "janet.lsp.enableDebug",
+				"title": "Enable Debug Logging",
+				"when": "editorLangId == janet",
+				"enablement": "editorLangId == janet"
+			},
+			{
+				"category": "Janet LSP",
+				"command": "janet.lsp.disableDebug",
+				"title": "Disable Debug Logging",
 				"when": "editorLangId == janet",
 				"enablement": "editorLangId == janet"
 			},

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Janet++",
 	"description": "Expanded Janet language support for Visual Studio Code",
 	"icon": "images/icon_png_minimal_glow.png",
-	"version": "1.1.8",
+	"version": "1.1.9",
 	"author": "Caleb Figgers",
 	"publisher": "CalebFiggers",
 	"repository": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode';
-import { customREPLCommandSnippet } from './evaluate';
+// import { customREPLCommandSnippet } from './evaluate';
 // import { ReplConnectSequence } from './nrepl/connectSequence';
 // import { PrettyPrintingOptions } from './printer';
 // import { parseEdn } from '../out/cljs-lib/cljs-lib';
-import { getProjectConfig } from './state';
+// import { getProjectConfig } from './state';
 import _ = require('lodash');
 // import { isDefined } from './utilities';
 
@@ -95,75 +95,21 @@ function _trimAliasName(name: string): string {
 //   false
 // );
 
-// watcher.onDidChange((uri: vscode.Uri) => {
-//   void readEdnWorkspaceConfig(uri);
-// });
-
 // TODO find a way to validate the configs
 function getConfig() {
   const configOptions = vscode.workspace.getConfiguration('janet');
   const pareditOptions = vscode.workspace.getConfiguration('janet.paredit');
   const lspOptions = vscode.workspace.getConfiguration('janet.lsp');
 
-  const w =
-    configOptions.inspect<customREPLCommandSnippet[]>('customREPLCommandSnippets')
-      ?.workspaceValue ?? [];
-  const commands = w.concat(
-    (getProjectConfig()?.customREPLCommandSnippets as customREPLCommandSnippet[]) ?? []
-  );
-  const hoverSnippets = (
-    configOptions.inspect<customREPLCommandSnippet[]>('customREPLHoverSnippets')?.workspaceValue ??
-    []
-  ).concat((getProjectConfig()?.customREPLHoverSnippets as customREPLCommandSnippet[]) ?? []);
-
   return {
-    format: configOptions.get('formatOnSave'),
-    evaluate: configOptions.get('evalOnSave'),
-    test: configOptions.get('testOnSave'),
-    showDocstringInParameterHelp: configOptions.get<boolean>('showDocstringInParameterHelp'),
-    jackInEnv: configOptions.get('jackInEnv'),
-    jackInDependencyVersions: configOptions.get<{
-      JackInDependency: string;
-    }>('jackInDependencyVersions'),
-    clojureLspVersion: configOptions.get<string>('clojureLspVersion'),
-    clojureLspPath: configOptions.get<string>('clojureLspPath'),
-    openBrowserWhenFigwheelStarted: configOptions.get<boolean>('openBrowserWhenFigwheelStarted'),
-    customCljsRepl: configOptions.get('customCljsRepl', null),
-    // replConnectSequences: configOptions.get<ReplConnectSequence[]>('replConnectSequences'),
-    myLeinProfiles: configOptions.get<string[]>('myLeinProfiles', []).map(_trimAliasName),
-    myCljAliases: configOptions.get<string[]>('myCljAliases', []).map(_trimAliasName),
-    asyncOutputDestination: configOptions.get<string>('sendAsyncOutputTo'),
-    customREPLCommandSnippets: configOptions.get<customREPLCommandSnippet[]>(
-      'customREPLCommandSnippets',
-      []
-    ),
-    customREPLCommandSnippetsGlobal:
-      configOptions.inspect<customREPLCommandSnippet[]>('customREPLCommandSnippets')?.globalValue ??
-      [],
-    customREPLCommandSnippetsWorkspace: commands,
-    customREPLCommandSnippetsWorkspaceFolder:
-      configOptions.inspect<customREPLCommandSnippet[]>('customREPLCommandSnippets')
-        ?.workspaceFolderValue ?? [],
-    customREPLHoverSnippets: hoverSnippets,
-    // prettyPrintingOptions: configOptions.get<PrettyPrintingOptions>('prettyPrintingOptions'),
-    evaluationSendCodeToOutputWindow: configOptions.get<boolean>(
-      'evaluationSendCodeToOutputWindow'
-    ),
-    enableJSCompletions: configOptions.get<boolean>('enableJSCompletions'),
-    autoOpenREPLWindow: configOptions.get<boolean>('autoOpenREPLWindow'),
-    autoOpenJackInTerminal: configOptions.get('autoOpenJackInTerminal'),
-    referencesCodeLensEnabled: configOptions.get<boolean>('referencesCodeLens.enabled'),
-    hideReplUi: configOptions.get<boolean>('hideReplUi'),
     strictPreventUnmatchedClosingBracket: pareditOptions.get<boolean>(
       'strictPreventUnmatchedClosingBracket'
     ),
-    showCalvaSaysOnStart: configOptions.get<boolean>('showCalvaSaysOnStart'),
-    jackIn: {
-      useDeprecatedAliasFlag: configOptions.get<boolean>('jackIn.useDeprecatedAliasFlag'),
-    },
     projectRootsSearchExclude: configOptions.get<string[]>('projectRootsSearchExclude', []),
     useLiveShare: configOptions.get<boolean>('useLiveShare'),
     definitionProviderPriority: configOptions.get<string[]>('definitionProviderPriority'),
+
+    autoStartREPL: configOptions.get<boolean>('autoStartRepl'),
 
     // Janet LSP
     customJanetLspCommand: lspOptions.get<string>('customJanetLspCommand'),

--- a/src/config.ts
+++ b/src/config.ts
@@ -171,7 +171,8 @@ function getConfig() {
     enableLsp: lspOptions.get<boolean>('enableLsp'),
     debugLsp: lspOptions.get<boolean>('debugLsp'),
     loggingDetailConsole: lspOptions.get<string>('loggingdetail.console'),
-    loggingDetailFile: lspOptions.get<string>('loggingdetail.file')
+    loggingDetailFile: lspOptions.get<string>('loggingdetail.file'),
+    lspConsolePort: lspOptions.get<string>('consolePort')
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -169,7 +169,9 @@ function getConfig() {
     customJanetLspCommand: lspOptions.get<string>('customJanetLspCommand'),
     dontDiscoverJpmTree: lspOptions.get<boolean>('dontDiscoverJpmTree'),
     enableLsp: lspOptions.get<boolean>('enableLsp'),
-    debugLsp: lspOptions.get<boolean>('debugLsp')
+    debugLsp: lspOptions.get<boolean>('debugLsp'),
+    loggingDetailConsole: lspOptions.get<string>('loggingdetail.console'),
+    loggingDetailFile: lspOptions.get<string>('loggingdetail.file')
   };
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -321,6 +321,10 @@ export function activate(context: vscode.ExtensionContext) {
 			console.error('Failed activating LSP: ' + e.message);
 		}
 	}
+
+	if (config.getConfig().autoStartREPL) {
+		void vscode.commands.executeCommand('janet.startREPL');
+	}
 		
 	console.log('Extension "vscode-janet" is now active!');
 } 

--- a/src/lsp/extension.ts
+++ b/src/lsp/extension.ts
@@ -334,6 +334,10 @@ export function activate(context: ExtensionContext) {
     );
 
     context.subscriptions.push(
+        vscode.commands.registerCommand('janet.lsp.restartLsp', commandRestartLSP )
+    );
+
+    context.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration(async (e: vscode.ConfigurationChangeEvent) => {
             console.log("Configuration changed");
 
@@ -357,6 +361,20 @@ export function activate(context: ExtensionContext) {
     );
 
 	client.start();
+}
+
+async function commandRestartLSP() : Promise<void> {
+    const client = languageClients.get("janet-lsp");
+
+    if (client) {
+        await client?.sendRequest("shutdown", {}).then(() => {
+            client?.sendRequest("exit", {});
+        }).then(() => {
+            client?.start();
+        });
+    } else {
+        console.error("Janet LSP not found");
+    }
 }
 
 async function commandTellJoke() : Promise<void> {

--- a/src/lsp/extension.ts
+++ b/src/lsp/extension.ts
@@ -333,6 +333,29 @@ export function activate(context: ExtensionContext) {
         vscode.commands.registerCommand('janet.lsp.disableDebug', commandDisableDebug )
     );
 
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration(async (e: vscode.ConfigurationChangeEvent) => {
+            console.log("Configuration changed");
+
+            if (e.affectsConfiguration('janet.lsp.loggingdetail.console')) {
+                console.log("Configuration changed: janet.lsp.loggingdetail.console");
+                console.log('Current clients:', Array.from(languageClients.keys()));
+
+                const newLogLevel: string = vscode.workspace.getConfiguration().get('janet.lsp.loggingdetail.console');
+                // await commandTellJoke();
+                await setDebugLevel(newLogLevel);
+            }
+            if (e.affectsConfiguration('janet.lsp.loggingdetail.file')) {
+                console.log("Configuration changed: janet.lsp.loggingdetail.file");
+                console.log('Current clients:', Array.from(languageClients.keys()));
+
+                const newLogLevel: string = vscode.workspace.getConfiguration().get('janet.lsp.loggingdetail.file');
+                // await commandTellJoke();
+                await setDebugToFileLevel(newLogLevel);
+            }
+        })
+    );
+
 	client.start();
 }
 
@@ -375,6 +398,36 @@ async function commandDisableDebug() : Promise<void> {
     }
 }
 
+async function setDebugLevel(loglevel: string) : Promise<void> {
+    console.log("setDebugLevel called: Setting log level to: " + loglevel);
+
+    const client = languageClients.get("janet-lsp");
+    
+    if (client) {
+        console.log("Sending to ", client?.name || "none");
+        const result = await client.sendRequest("setLogLevel", {level: loglevel});
+        void vscode.window.showInformationMessage(
+            result["message"]
+        );
+    } else {
+        console.error("Janet LSP not found");
+    }
+}
+
+async function setDebugToFileLevel(loglevel: string) : Promise<void> {
+    console.log("setDebugToFileLevel called: Setting log to file level to: " + loglevel);
+
+    const client = languageClients.get("janet-lsp");
+
+    if (client) {
+        console.log("Sending to ", client?.name || "none");
+        const result = await client.sendRequest("setLogToFileLevel", {level: loglevel});
+        void vscode.window.showInformationMessage(
+            result["message"]
+        );
+    } else {
+        console.error("Janet LSP not found");
+    }
 }
 
 export function deactivate(){

--- a/src/lsp/extension.ts
+++ b/src/lsp/extension.ts
@@ -106,6 +106,60 @@ function getDebugLspOpt(): string[] {
     return debugLsp;
 }
 
+function getLoggingDetailConsole(): string[]{
+    let loggingDetailConsole: string[];
+
+    if (config.getConfig().loggingDetailConsole){
+        let level: number;
+        switch (config.getConfig().loggingDetailConsole) {
+            case "off":
+                level = 0;
+                break;
+            case "messages":
+                level = 1;
+                break;
+            case "verbose":
+                level = 2;
+                break;
+            case "veryverbose":
+                level = 3;
+                break;
+            default:
+                break;
+        }
+        loggingDetailConsole = ["--log-level", level.toString()];
+    }
+
+    return loggingDetailConsole;
+}
+
+function getLoggingDetailFile(): string[]{
+    let loggingDetailConsole: string[];
+
+    if (config.getConfig().loggingDetailFile){
+        let level: number;
+        switch (config.getConfig().loggingDetailFile) {
+            case "off":
+                level = 0;
+                break;
+            case "messages":
+                level = 1;
+                break;
+            case "verbose":
+                level = 2;
+                break;
+            case "veryverbose":
+                level = 3;
+                break;
+            default:
+                break;
+        }
+        loggingDetailConsole = ["--log-to-file-level", level.toString()];
+    }
+
+    return loggingDetailConsole;
+}
+
 function getServerOptions(): ServerOptions {
     let options: ServerOptions;
     const lspConfig = config.getConfig().customJanetLspCommand;
@@ -118,10 +172,16 @@ function getServerOptions(): ServerOptions {
             transport: TransportKind.stdio
         };
     } else {
+        const args = ["-i", getServerImage()].concat(
+            getDebugLspOpt(),
+            getDiscoverJpmTreeOpt(),
+            getLoggingDetailConsole(),
+            getLoggingDetailFile()
+        );
+        console.log("LSP args are: ", args);
         options = {
             command: "janet",
-            args: ["-i", getServerImage()]
-                .concat(getDiscoverJpmTreeOpt(), getDebugLspOpt()),
+            args: args,
             transport: TransportKind.stdio
         };
     }
@@ -263,6 +323,14 @@ export function activate(context: ExtensionContext) {
 
     context.subscriptions.push(
         vscode.commands.registerCommand('janet.lsp.tellJoke', commandTellJoke )
+    );
+    
+    context.subscriptions.push(
+        vscode.commands.registerCommand('janet.lsp.enableDebug', commandEnableDebug )
+    );
+    
+    context.subscriptions.push(
+        vscode.commands.registerCommand('janet.lsp.disableDebug', commandDisableDebug )
     );
 
 	client.start();

--- a/src/lsp/extension.ts
+++ b/src/lsp/extension.ts
@@ -282,6 +282,31 @@ async function commandTellJoke() : Promise<void> {
     }
 }
 
+async function commandEnableDebug() : Promise<void> {
+    const client = languageClients.get("janet-lsp");
+    if (client) {
+        const result = await client?.sendRequest("enableDebug", {});
+        void vscode.window.showInformationMessage(
+            result["message"]
+        );
+
+    } else {
+        console.error("Janet LSP not found");
+    }
+}
+
+async function commandDisableDebug() : Promise<void> {
+    const client = languageClients.get("janet-lsp");
+    if (client) {
+        const result = await client?.sendRequest("disableDebug", {});
+        void vscode.window.showInformationMessage(
+            result["message"]
+        );
+    } else {
+        console.error("Janet LSP not found");
+    }
+}
+
 }
 
 export function deactivate(){

--- a/src/lsp/extension.ts
+++ b/src/lsp/extension.ts
@@ -106,6 +106,18 @@ function getDebugLspOpt(): string[] {
     return debugLsp;
 }
 
+function getConsolePort(): string[] {
+    let debugLsp: string[];
+
+    if (config.getConfig().lspConsolePort) {
+        debugLsp = ["--debug-port", config.getConfig().lspConsolePort];
+    } else {
+        debugLsp = [];
+    }
+
+    return debugLsp;
+}
+
 function getLoggingDetailConsole(): string[]{
     let loggingDetailConsole: string[];
 
@@ -176,7 +188,8 @@ function getServerOptions(): ServerOptions {
             getDebugLspOpt(),
             getDiscoverJpmTreeOpt(),
             getLoggingDetailConsole(),
-            getLoggingDetailFile()
+            getLoggingDetailFile(),
+            getConsolePort()
         );
         console.log("LSP args are: ", args);
         options = {


### PR DESCRIPTION
- Extension
  - New feature: Auto-activate extension when `project.janet` is detected in project tree
  - New feature: Setting to auto-start REPL on extension activation
- Settings
  - New option to enable Debug flag on launch
  - New options to set LSP Log level and Log to File Level (on launch and on change)
  - New option to set Console port on launch
- Janet LSP
  - Update to v0.0.10 
    - Logging 
      - Rotate log files and overwrite eventually to avoid indefinite log file size
      - Adjusted some log levels
    - New methods
      - `enableDebug` and `disableDebug` - Allow clients to set `(dyn :debug)` while running
      - `setLogLevel` and `setLogToFileLevel` - Allow clients to change debug level to console and file
  - Related commands 
    - New commands to Enable and Disable Debug
    - New commands to set Log Level and Log to File Level
    - New command to Restart LSP