### PR TITLE
Quick patch: Revert a deleted line

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -102,6 +102,7 @@ function getConfig() {
   const lspOptions = vscode.workspace.getConfiguration('janet.lsp');
 
   return {
+    format: configOptions.get('formatOnSave'),
     strictPreventUnmatchedClosingBracket: pareditOptions.get<boolean>(
       'strictPreventUnmatchedClosingBracket'
     ),


### PR DESCRIPTION
- Overzealous removal of the `format` key from `getConfig()`'s return in 7d50a96d